### PR TITLE
add ui and e2e test wrapped by Makefile

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -34,3 +34,37 @@ jobs:
       # Let the Makefile handle ALL the logic (Setup, Simulator, Linting, Tests, Teardown)
       - name: Run Makefile Checks
         run: make verify
+
+  ui-e2e:
+    name: UI End-to-End Test
+    runs-on: ubuntu-latest
+    needs: verify
+    env:
+      MINITWIT_GUI_URL: http://localhost:8080/register
+      MINITWIT_DB_URL: mongodb://localhost:27017/test
+      MINITWIT_HEADLESS: "1"
+      GECKODRIVER_PATH: /usr/local/bin/geckodriver
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Setup Firefox
+        uses: browser-actions/setup-firefox@v1
+
+      - name: Install geckodriver
+        run: |
+          GECKO_VERSION="v0.36.0"
+          curl -sSL -o geckodriver.tar.gz "https://github.com/mozilla/geckodriver/releases/download/${GECKO_VERSION}/geckodriver-${GECKO_VERSION}-linux64.tar.gz"
+          tar -xzf geckodriver.tar.gz
+          sudo mv geckodriver /usr/local/bin/geckodriver
+          sudo chmod +x /usr/local/bin/geckodriver
+          geckodriver --version
+
+      - name: Run UI E2E via Makefile
+        run: make ui-e2e

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ RESET  := $(shell tput -Txterm sgr0)
 
 GO_DIR=new
 DOCKER_FILES=$(shell find . -name "Dockerfile*")
+GECKODRIVER_BIN=$(shell command -v geckodriver 2>/dev/null)
 
 ci-setup:
 	@echo "$(CYAN)==> Starting containers in background...$(RESET)"
@@ -62,6 +63,42 @@ test:
 	@echo "$(CYAN)==> Running Go unit tests...$(RESET)"
 	cd $(GO_DIR) && go test -v ./...
 
+wait-web:
+	@echo "$(CYAN)==> Waiting for webserver readiness on /register...$(RESET)"
+	@for i in $$(seq 1 45); do \
+		status=$$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/register || true); \
+		if [ "$$status" = "200" ]; then \
+			echo "$(GREEN)Webserver is ready.$(RESET)"; \
+			exit 0; \
+		fi; \
+		echo "waiting... ($$i/45) status=$$status"; \
+		sleep 2; \
+	done; \
+	echo "$(RED)Webserver did not become ready in time.$(RESET)"; \
+	exit 1
+
+ui-e2e:
+	@echo "$(CYAN)==> Running UI end-to-end tests...$(RESET)"
+	@set -e; \
+	GECKO_PATH="$${GECKODRIVER_PATH:-$(GECKODRIVER_BIN)}"; \
+	if [ -z "$$GECKO_PATH" ]; then \
+		echo "$(RED)geckodriver not found. Set GECKODRIVER_PATH or install geckodriver in PATH.$(RESET)"; \
+		exit 1; \
+	fi; \
+	python3 -m pip install -r requirements-test.txt; \
+	docker compose up -d --force-recreate dbserver webserver; \
+	trap 'docker compose down -v' EXIT; \
+	$(MAKE) wait-web; \
+	MINITWIT_GUI_URL="$${MINITWIT_GUI_URL:-http://localhost:8080/register}" \
+	MINITWIT_DB_URL="$${MINITWIT_DB_URL:-mongodb://localhost:27017/test}" \
+	MINITWIT_HEADLESS="$${MINITWIT_HEADLESS:-1}" \
+	GECKODRIVER_PATH="$$GECKO_PATH" \
+	python3 -m pytest -v test_itu_minitwit_ui.py || { \
+		echo "$(RED)UI E2E test failed; printing container logs...$(RESET)"; \
+		docker compose logs --tail=120 webserver dbserver || true; \
+		exit 1; \
+	}
+
 # --------- Execute tests --------------------------
 
 # if one test file, still environment is cleaned up correctly
@@ -74,4 +111,4 @@ verify:
 # Helper to group all checks together
 run-checks: test-sim fmt lint-go lint-docker test
 
-.PHONY: ci-setup test-sim fmt lint-go lint-docker test verify ci-cleanup run-checks
+.PHONY: ci-setup test-sim fmt lint-go lint-docker test verify ci-cleanup run-checks wait-web ui-e2e

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest
+pymongo
+selenium

--- a/test_itu_minitwit_ui.py
+++ b/test_itu_minitwit_ui.py
@@ -1,0 +1,102 @@
+"""
+To run this test with a visible browser, the following dependencies have to be setup:
+
+  * `pip install selenium`
+  * `pip install pymongo`
+  * `pip install pytest`
+  * `wget https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz`
+  * `tar xzvf geckodriver-v0.32.0-linux64.tar.gz`
+  * After extraction, the downloaded artifact can be removed: `rm geckodriver-v0.32.0-linux64.tar.gz`
+
+The application that it tests is the version of _ITU-MiniTwit_ that you got to know during the exercises on Docker:
+https://github.com/itu-devops/flask-minitwit-mongodb/tree/Containerize (*OBS*: branch Containerize)
+
+```bash
+$ git clone https://github.com/HelgeCPH/flask-minitwit-mongodb.git
+$ cd flask-minitwit-mongodb
+$ git switch Containerize
+```
+
+After editing the `docker-compose.yml` file file where you replace `youruser` with your respective username, the
+application can be started with `docker-compose up`.
+
+Now, the test itself can be executed via: `pytest test_itu_minitwit_ui.py`.
+"""
+
+import os
+
+import pymongo
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.firefox.service import Service
+from selenium.webdriver.firefox.options import Options
+
+
+GUI_URL = os.getenv("MINITWIT_GUI_URL", "http://localhost:8080/register")
+DB_URL = os.getenv("MINITWIT_DB_URL", "mongodb://localhost:27017/test")
+GECKODRIVER_PATH = os.getenv("GECKODRIVER_PATH", "./geckodriver")
+HEADLESS = os.getenv("MINITWIT_HEADLESS", "1").strip().lower() not in {"0", "false", "no"}
+
+
+def _register_user_via_gui(driver, data):
+    driver.get(GUI_URL)
+
+    wait = WebDriverWait(driver, 5)
+    wait.until(EC.presence_of_element_located((By.NAME, "username")))
+
+    driver.find_element(By.NAME, "username").send_keys(data[0])
+    driver.find_element(By.NAME, "email").send_keys(data[1])
+    driver.find_element(By.NAME, "password").send_keys(data[2])
+    driver.find_element(By.NAME, "password2").send_keys(data[3])
+
+    driver.find_element(By.CSS_SELECTOR, "form[action='/register'] button[type='submit']").click()
+
+    wait.until(EC.url_contains("/login"))
+    return driver.current_url
+
+
+def _get_user_by_name(db_client, name):
+    return db_client.test.user.find_one({"username": name})
+
+
+def test_register_user_via_gui():
+    """
+    This is a UI test. It only interacts with the UI that is rendered in the browser and checks that visual
+    responses that users observe are displayed.
+    """
+    firefox_options = Options()
+    if HEADLESS:
+        firefox_options.add_argument("--headless")
+    # firefox_options = None
+    with webdriver.Firefox(service=Service(GECKODRIVER_PATH), options=firefox_options) as driver:
+        current_url = _register_user_via_gui(driver, ["Me", "me@some.where", "secure123", "secure123"])
+        assert "/login" in current_url
+
+    # cleanup, make test case idempotent
+    db_client = pymongo.MongoClient(DB_URL, serverSelectionTimeoutMS=5000)
+    db_client.test.user.delete_one({"username": "Me"})
+
+
+def test_register_user_via_gui_and_check_db_entry():
+    """
+    This is an end-to-end test. Before registering a user via the UI, it checks that no such user exists in the
+    database yet. After registering a user, it checks that the respective user appears in the database.
+    """
+    firefox_options = Options()
+    if HEADLESS:
+        firefox_options.add_argument("--headless")
+    # firefox_options = None
+    with webdriver.Firefox(service=Service(GECKODRIVER_PATH), options=firefox_options) as driver:
+        db_client = pymongo.MongoClient(DB_URL, serverSelectionTimeoutMS=5000)
+
+        assert _get_user_by_name(db_client, "Me") == None
+
+        current_url = _register_user_via_gui(driver, ["Me", "me@some.where", "secure123", "secure123"])
+        assert "/login" in current_url
+
+        assert _get_user_by_name(db_client, "Me")["username"] == "Me"
+
+        # cleanup, make test case idempotent
+        db_client.test.user.delete_one({"username": "Me"})


### PR DESCRIPTION
# Summary
This PR adds a stable UI end-to-end testing flow for the MiniTwit web app and integrates it into CI so it runs automatically on push and pull request.

# What changed
Added configurable Selenium UI/E2E test support in test_itu_minitwit_ui.py.
Added test dependency manifest in requirements-test.txt.
Added Makefile target for local and CI execution:
Makefile
new targets: wait-web and ui-e2e
Extended CI workflow with a dedicated UI E2E job:
.github/workflows/static-analysis.yml
new job: ui-e2e (runs after verify)

# Local run
Run:
make ui-e2e

This target:

installs Python test deps
starts dbserver and webserver
waits for /register readiness
runs pytest for UI E2E
tears down containers automatically