### PR TITLE
UI and E2E tests

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -34,3 +34,37 @@ jobs:
       # Let the Makefile handle ALL the logic (Setup, Simulator, Linting, Tests, Teardown)
       - name: Run Makefile Checks
         run: make verify
+
+  ui-e2e:
+    name: UI End-to-End Test
+    runs-on: ubuntu-latest
+    needs: verify
+    env:
+      MINITWIT_GUI_URL: http://localhost:8080/register
+      MINITWIT_DB_URL: mongodb://localhost:27017/test
+      MINITWIT_HEADLESS: "1"
+      GECKODRIVER_PATH: /usr/local/bin/geckodriver
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Setup Firefox
+        uses: browser-actions/setup-firefox@v1
+
+      - name: Install geckodriver
+        run: |
+          GECKO_VERSION="v0.36.0"
+          curl -sSL -o geckodriver.tar.gz "https://github.com/mozilla/geckodriver/releases/download/${GECKO_VERSION}/geckodriver-${GECKO_VERSION}-linux64.tar.gz"
+          tar -xzf geckodriver.tar.gz
+          sudo mv geckodriver /usr/local/bin/geckodriver
+          sudo chmod +x /usr/local/bin/geckodriver
+          geckodriver --version
+
+      - name: Run UI E2E via Makefile
+        run: make ui-e2e

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ RESET  := $(shell tput -Txterm sgr0)
 
 GO_DIR=new
 DOCKER_FILES=$(shell find . -name "Dockerfile*")
+GECKODRIVER_BIN=$(shell command -v geckodriver 2>/dev/null)
 
 ci-setup:
 	@echo "$(CYAN)==> Starting containers in background...$(RESET)"
@@ -62,6 +63,42 @@ test:
 	@echo "$(CYAN)==> Running Go unit tests...$(RESET)"
 	cd $(GO_DIR) && go test -v ./...
 
+wait-web:
+	@echo "$(CYAN)==> Waiting for webserver readiness on /register...$(RESET)"
+	@for i in $$(seq 1 45); do \
+		status=$$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/register || true); \
+		if [ "$$status" = "200" ]; then \
+			echo "$(GREEN)Webserver is ready.$(RESET)"; \
+			exit 0; \
+		fi; \
+		echo "waiting... ($$i/45) status=$$status"; \
+		sleep 2; \
+	done; \
+	echo "$(RED)Webserver did not become ready in time.$(RESET)"; \
+	exit 1
+
+ui-e2e:
+	@echo "$(CYAN)==> Running UI end-to-end tests...$(RESET)"
+	@set -e; \
+	GECKO_PATH="$${GECKODRIVER_PATH:-$(GECKODRIVER_BIN)}"; \
+	if [ -z "$$GECKO_PATH" ]; then \
+		echo "$(RED)geckodriver not found. Set GECKODRIVER_PATH or install geckodriver in PATH.$(RESET)"; \
+		exit 1; \
+	fi; \
+	python3 -m pip install -r requirements-test.txt; \
+	docker compose up -d --force-recreate dbserver webserver; \
+	trap 'docker compose down -v' EXIT; \
+	$(MAKE) wait-web; \
+	MINITWIT_GUI_URL="$${MINITWIT_GUI_URL:-http://localhost:8080/register}" \
+	MINITWIT_DB_URL="$${MINITWIT_DB_URL:-mongodb://localhost:27017/test}" \
+	MINITWIT_HEADLESS="$${MINITWIT_HEADLESS:-1}" \
+	GECKODRIVER_PATH="$$GECKO_PATH" \
+	python3 -m pytest -v test_itu_minitwit_ui.py || { \
+		echo "$(RED)UI E2E test failed; printing container logs...$(RESET)"; \
+		docker compose logs --tail=120 webserver dbserver || true; \
+		exit 1; \
+	}
+
 # --------- Execute tests --------------------------
 
 # if one test file, still environment is cleaned up correctly
@@ -74,4 +111,4 @@ verify:
 # Helper to group all checks together
 run-checks: test-sim fmt lint-go lint-docker test
 
-.PHONY: ci-setup test-sim fmt lint-go lint-docker test verify ci-cleanup run-checks
+.PHONY: ci-setup test-sim fmt lint-go lint-docker test verify ci-cleanup run-checks wait-web ui-e2e

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+pytest
+pymongo
+selenium

--- a/test_itu_minitwit_ui.py
+++ b/test_itu_minitwit_ui.py
@@ -1,0 +1,102 @@
+"""
+To run this test with a visible browser, the following dependencies have to be setup:
+
+  * `pip install selenium`
+  * `pip install pymongo`
+  * `pip install pytest`
+  * `wget https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz`
+  * `tar xzvf geckodriver-v0.32.0-linux64.tar.gz`
+  * After extraction, the downloaded artifact can be removed: `rm geckodriver-v0.32.0-linux64.tar.gz`
+
+The application that it tests is the version of _ITU-MiniTwit_ that you got to know during the exercises on Docker:
+https://github.com/itu-devops/flask-minitwit-mongodb/tree/Containerize (*OBS*: branch Containerize)
+
+```bash
+$ git clone https://github.com/HelgeCPH/flask-minitwit-mongodb.git
+$ cd flask-minitwit-mongodb
+$ git switch Containerize
+```
+
+After editing the `docker-compose.yml` file file where you replace `youruser` with your respective username, the
+application can be started with `docker-compose up`.
+
+Now, the test itself can be executed via: `pytest test_itu_minitwit_ui.py`.
+"""
+
+import os
+
+import pymongo
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.firefox.service import Service
+from selenium.webdriver.firefox.options import Options
+
+
+GUI_URL = os.getenv("MINITWIT_GUI_URL", "http://localhost:8080/register")
+DB_URL = os.getenv("MINITWIT_DB_URL", "mongodb://localhost:27017/test")
+GECKODRIVER_PATH = os.getenv("GECKODRIVER_PATH", "./geckodriver")
+HEADLESS = os.getenv("MINITWIT_HEADLESS", "1").strip().lower() not in {"0", "false", "no"}
+
+
+def _register_user_via_gui(driver, data):
+    driver.get(GUI_URL)
+
+    wait = WebDriverWait(driver, 5)
+    wait.until(EC.presence_of_element_located((By.NAME, "username")))
+
+    driver.find_element(By.NAME, "username").send_keys(data[0])
+    driver.find_element(By.NAME, "email").send_keys(data[1])
+    driver.find_element(By.NAME, "password").send_keys(data[2])
+    driver.find_element(By.NAME, "password2").send_keys(data[3])
+
+    driver.find_element(By.CSS_SELECTOR, "form[action='/register'] button[type='submit']").click()
+
+    wait.until(EC.url_contains("/login"))
+    return driver.current_url
+
+
+def _get_user_by_name(db_client, name):
+    return db_client.test.user.find_one({"username": name})
+
+
+def test_register_user_via_gui():
+    """
+    This is a UI test. It only interacts with the UI that is rendered in the browser and checks that visual
+    responses that users observe are displayed.
+    """
+    firefox_options = Options()
+    if HEADLESS:
+        firefox_options.add_argument("--headless")
+    # firefox_options = None
+    with webdriver.Firefox(service=Service(GECKODRIVER_PATH), options=firefox_options) as driver:
+        current_url = _register_user_via_gui(driver, ["Me", "me@some.where", "secure123", "secure123"])
+        assert "/login" in current_url
+
+    # cleanup, make test case idempotent
+    db_client = pymongo.MongoClient(DB_URL, serverSelectionTimeoutMS=5000)
+    db_client.test.user.delete_one({"username": "Me"})
+
+
+def test_register_user_via_gui_and_check_db_entry():
+    """
+    This is an end-to-end test. Before registering a user via the UI, it checks that no such user exists in the
+    database yet. After registering a user, it checks that the respective user appears in the database.
+    """
+    firefox_options = Options()
+    if HEADLESS:
+        firefox_options.add_argument("--headless")
+    # firefox_options = None
+    with webdriver.Firefox(service=Service(GECKODRIVER_PATH), options=firefox_options) as driver:
+        db_client = pymongo.MongoClient(DB_URL, serverSelectionTimeoutMS=5000)
+
+        assert _get_user_by_name(db_client, "Me") == None
+
+        current_url = _register_user_via_gui(driver, ["Me", "me@some.where", "secure123", "secure123"])
+        assert "/login" in current_url
+
+        assert _get_user_by_name(db_client, "Me")["username"] == "Me"
+
+        # cleanup, make test case idempotent
+        db_client.test.user.delete_one({"username": "Me"})

--- a/test_itu_minitwit_ui.py
+++ b/test_itu_minitwit_ui.py
@@ -1,29 +1,25 @@
 """
-To run this test with a visible browser, the following dependencies have to be setup:
+UI and end-to-end tests for ITU MiniTwit.
 
-  * `pip install selenium`
-  * `pip install pymongo`
-  * `pip install pytest`
-  * `wget https://github.com/mozilla/geckodriver/releases/download/v0.32.0/geckodriver-v0.32.0-linux64.tar.gz`
-  * `tar xzvf geckodriver-v0.32.0-linux64.tar.gz`
-  * After extraction, the downloaded artifact can be removed: `rm geckodriver-v0.32.0-linux64.tar.gz`
+Origin:
+    This file is based on the Selenium test that was offered in Session 7.
 
-The application that it tests is the version of _ITU-MiniTwit_ that you got to know during the exercises on Docker:
-https://github.com/itu-devops/flask-minitwit-mongodb/tree/Containerize (*OBS*: branch Containerize)
+Refactor note:
+    The original Session 7 test targeted the legacy Flask implementation.
+    This version was refactored to match the current itu-minitwit architecture
+    (Go web app + MongoDB + current routes/templates) and to run in local and CI
+    environments via environment-variable configuration.
 
-```bash
-$ git clone https://github.com/HelgeCPH/flask-minitwit-mongodb.git
-$ cd flask-minitwit-mongodb
-$ git switch Containerize
-```
+Typical local run:
+    make ui-e2e
 
-After editing the `docker-compose.yml` file file where you replace `youruser` with your respective username, the
-application can be started with `docker-compose up`.
-
-Now, the test itself can be executed via: `pytest test_itu_minitwit_ui.py`.
+Direct run:
+    GECKODRIVER_PATH=/opt/homebrew/bin/geckodriver \
+    python -m pytest -v test_itu_minitwit_ui.py
 """
 
 import os
+import uuid
 
 import pymongo
 from selenium import webdriver
@@ -38,6 +34,22 @@ GUI_URL = os.getenv("MINITWIT_GUI_URL", "http://localhost:8080/register")
 DB_URL = os.getenv("MINITWIT_DB_URL", "mongodb://localhost:27017/test")
 GECKODRIVER_PATH = os.getenv("GECKODRIVER_PATH", "./geckodriver")
 HEADLESS = os.getenv("MINITWIT_HEADLESS", "1").strip().lower() not in {"0", "false", "no"}
+BASE_URL = GUI_URL.rsplit("/register", 1)[0]
+
+
+def _unique_token(prefix):
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+def _mongo_client():
+    return pymongo.MongoClient(DB_URL, serverSelectionTimeoutMS=5000)
+
+
+def _new_driver():
+    firefox_options = Options()
+    if HEADLESS:
+        firefox_options.add_argument("--headless")
+    return webdriver.Firefox(service=Service(GECKODRIVER_PATH), options=firefox_options)
 
 
 def _register_user_via_gui(driver, data):
@@ -57,6 +69,51 @@ def _register_user_via_gui(driver, data):
     return driver.current_url
 
 
+def _login_user_via_gui(driver, username, password):
+    driver.get(f"{BASE_URL}/login")
+
+    wait = WebDriverWait(driver, 8)
+    wait.until(EC.presence_of_element_located((By.NAME, "username")))
+
+    driver.find_element(By.NAME, "username").send_keys(username)
+    driver.find_element(By.NAME, "password").send_keys(password)
+    driver.find_element(By.CSS_SELECTOR, "form[action='/login'] button[type='submit']").click()
+
+    wait.until(EC.url_to_be(f"{BASE_URL}/"))
+    return driver.current_url
+
+
+def _seed_user(db_client, username, email=None, password="secure123"):
+    user_doc = {
+        "username": username,
+        "email": email or f"{username}@example.test",
+        "pw": password,
+        "hashedpw": password,
+    }
+    result = db_client.test.user.insert_one(user_doc)
+    user_doc["_id"] = result.inserted_id
+    return user_doc
+
+
+def _cleanup_test_data(db_client, usernames=None, message_prefixes=None):
+    usernames = usernames or []
+    message_prefixes = message_prefixes or []
+
+    users = list(db_client.test.user.find({"username": {"$in": usernames}}, {"_id": 1, "username": 1}))
+    user_ids = [u["_id"] for u in users]
+
+    if user_ids:
+        db_client.test.follower.delete_many({"$or": [{"who_id": {"$in": user_ids}}, {"whom_id": {"$in": user_ids}}]})
+        db_client.test.message.delete_many({"author_id": {"$in": user_ids}})
+
+    if message_prefixes:
+        for prefix in message_prefixes:
+            db_client.test.message.delete_many({"text": {"$regex": f"^{prefix}"}})
+
+    if usernames:
+        db_client.test.user.delete_many({"username": {"$in": usernames}})
+
+
 def _get_user_by_name(db_client, name):
     return db_client.test.user.find_one({"username": name})
 
@@ -66,17 +123,14 @@ def test_register_user_via_gui():
     This is a UI test. It only interacts with the UI that is rendered in the browser and checks that visual
     responses that users observe are displayed.
     """
-    firefox_options = Options()
-    if HEADLESS:
-        firefox_options.add_argument("--headless")
-    # firefox_options = None
-    with webdriver.Firefox(service=Service(GECKODRIVER_PATH), options=firefox_options) as driver:
-        current_url = _register_user_via_gui(driver, ["Me", "me@some.where", "secure123", "secure123"])
+    username = _unique_token("ui_register")
+    db_client = _mongo_client()
+    try:
+        with _new_driver() as driver:
+            current_url = _register_user_via_gui(driver, [username, f"{username}@example.test", "secure123", "secure123"])
         assert "/login" in current_url
-
-    # cleanup, make test case idempotent
-    db_client = pymongo.MongoClient(DB_URL, serverSelectionTimeoutMS=5000)
-    db_client.test.user.delete_one({"username": "Me"})
+    finally:
+        _cleanup_test_data(db_client, usernames=[username])
 
 
 def test_register_user_via_gui_and_check_db_entry():
@@ -84,19 +138,128 @@ def test_register_user_via_gui_and_check_db_entry():
     This is an end-to-end test. Before registering a user via the UI, it checks that no such user exists in the
     database yet. After registering a user, it checks that the respective user appears in the database.
     """
-    firefox_options = Options()
-    if HEADLESS:
-        firefox_options.add_argument("--headless")
-    # firefox_options = None
-    with webdriver.Firefox(service=Service(GECKODRIVER_PATH), options=firefox_options) as driver:
-        db_client = pymongo.MongoClient(DB_URL, serverSelectionTimeoutMS=5000)
+    username = _unique_token("e2e_register")
+    db_client = _mongo_client()
+    try:
+        with _new_driver() as driver:
+            assert _get_user_by_name(db_client, username) is None
 
-        assert _get_user_by_name(db_client, "Me") == None
+            current_url = _register_user_via_gui(driver, [username, f"{username}@example.test", "secure123", "secure123"])
+            assert "/login" in current_url
 
-        current_url = _register_user_via_gui(driver, ["Me", "me@some.where", "secure123", "secure123"])
-        assert "/login" in current_url
+            assert _get_user_by_name(db_client, username)["username"] == username
+    finally:
+        _cleanup_test_data(db_client, usernames=[username])
 
-        assert _get_user_by_name(db_client, "Me")["username"] == "Me"
 
-        # cleanup, make test case idempotent
-        db_client.test.user.delete_one({"username": "Me"})
+def test_login_and_logout_ui_flow():
+    username = _unique_token("ui_login")
+    db_client = _mongo_client()
+
+    try:
+        _seed_user(db_client, username, password="secure123")
+
+        with _new_driver() as driver:
+            _login_user_via_gui(driver, username, "secure123")
+
+            wait = WebDriverWait(driver, 8)
+            wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "a[href='/logout']")))
+            assert f"Sign out [{username}]" in driver.page_source
+
+            driver.find_element(By.CSS_SELECTOR, "a[href='/logout']").click()
+            wait.until(EC.url_to_be(f"{BASE_URL}/"))
+            wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, "a[href='/login']")))
+
+            page = driver.page_source
+            assert "Sign In" in page
+            assert "Sign Up" in page
+            assert "Sign out" not in page
+    finally:
+        _cleanup_test_data(db_client, usernames=[username])
+
+
+def test_register_duplicate_username_validation():
+    username = _unique_token("dup_user")
+    db_client = _mongo_client()
+
+    try:
+        _seed_user(db_client, username, password="secure123")
+
+        with _new_driver() as driver:
+            driver.get(GUI_URL)
+            wait = WebDriverWait(driver, 8)
+            wait.until(EC.presence_of_element_located((By.NAME, "username")))
+
+            driver.find_element(By.NAME, "username").send_keys(username)
+            driver.find_element(By.NAME, "email").send_keys(f"{username}@example.test")
+            driver.find_element(By.NAME, "password").send_keys("secure123")
+            driver.find_element(By.NAME, "password2").send_keys("secure123")
+            driver.find_element(By.CSS_SELECTOR, "form[action='/register'] button[type='submit']").click()
+
+            wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, ".alert")))
+            assert "The username is already taken" in driver.page_source
+
+            users = list(db_client.test.user.find({"username": username}))
+            assert len(users) == 1
+    finally:
+        _cleanup_test_data(db_client, usernames=[username])
+
+
+def test_post_message_via_ui_and_check_db_entry():
+    username = _unique_token("msg_user")
+    message_text = f"E2E_MSG_{_unique_token('post')}"
+    db_client = _mongo_client()
+
+    try:
+        user_doc = _seed_user(db_client, username, password="secure123")
+
+        with _new_driver() as driver:
+            _login_user_via_gui(driver, username, "secure123")
+
+            wait = WebDriverWait(driver, 8)
+            wait.until(EC.presence_of_element_located((By.NAME, "text")))
+            driver.find_element(By.NAME, "text").send_keys(message_text)
+            driver.find_element(By.CSS_SELECTOR, "form[action='/add_message'] button[type='submit']").click()
+
+            wait.until(EC.url_to_be(f"{BASE_URL}/"))
+            wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, ".list-group-item")))
+
+            assert message_text in driver.page_source
+
+            db_msg = db_client.test.message.find_one({"text": message_text, "author_id": user_doc["_id"]})
+            assert db_msg is not None
+    finally:
+        _cleanup_test_data(db_client, usernames=[username], message_prefixes=["E2E_MSG_"])
+
+
+def test_follow_unfollow_via_ui_and_check_db_entry():
+    follower_username = _unique_token("follower")
+    target_username = _unique_token("target")
+    db_client = _mongo_client()
+
+    try:
+        follower_doc = _seed_user(db_client, follower_username, password="secure123")
+        target_doc = _seed_user(db_client, target_username, password="secure123")
+
+        with _new_driver() as driver:
+            _login_user_via_gui(driver, follower_username, "secure123")
+
+            wait = WebDriverWait(driver, 8)
+            driver.get(f"{BASE_URL}/user/{target_username}")
+            follow_selector = f"a[href='/user/follow/{target_username}']"
+            unfollow_selector = f"a[href='/user/unfollow/{target_username}']"
+
+            wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, follow_selector)))
+            driver.find_element(By.CSS_SELECTOR, follow_selector).click()
+
+            wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, unfollow_selector)))
+            relation = db_client.test.follower.find_one({"who_id": follower_doc["_id"], "whom_id": target_doc["_id"]})
+            assert relation is not None
+
+            driver.find_element(By.CSS_SELECTOR, unfollow_selector).click()
+            wait.until(EC.presence_of_element_located((By.CSS_SELECTOR, follow_selector)))
+
+            relation = db_client.test.follower.find_one({"who_id": follower_doc["_id"], "whom_id": target_doc["_id"]})
+            assert relation is None
+    finally:
+        _cleanup_test_data(db_client, usernames=[follower_username, target_username])


### PR DESCRIPTION
## Summary
This PR implements a robust UI and end-to-end testing pipeline for MiniTwit using Selenium + pytest, and wires it into both local developer workflow and GitHub Actions CI.

The test file is based on the Session 7 offered test and was refactored to fit the current itu-minitwit architecture (Go web app, current templates/routes, MongoDB-backed assertions, and CI-friendly configuration).

## What changed

### 1. UI/E2E test suite refactor and expansion
Updated test_itu_minitwit_ui.py:

- Refactored original Session 7 test assumptions to current app behavior:
  - register route/UI on port 8080 flow
  - button-based submit and current form selectors
  - success assertions aligned with current redirect behavior
- Added environment-driven configuration:
  - `MINITWIT_GUI_URL`
  - `MINITWIT_DB_URL`
  - `GECKODRIVER_PATH`
  - `MINITWIT_HEADLESS`
- Added reusable helper utilities for:
  - Selenium driver setup
  - UI login/register operations
  - DB user seeding and deterministic cleanup
  - unique test data generation to avoid collisions

### 2. New tests added

1. `test_login_and_logout_ui_flow`  
UI test: login state and logout state transitions in navigation/UI.

2. `test_register_duplicate_username_validation`  
UI + DB precondition test for duplicate username handling.

3. `test_post_message_via_ui_and_check_db_entry`  
E2E test: post via UI, verify message appears in UI and DB.

4. `test_follow_unfollow_via_ui_and_check_db_entry`  
E2E test: follow/unfollow via UI, verify follower relation create/remove in DB.

### 3. Test dependencies
Added requirements-test.txt for test-specific Python dependencies (`pytest`, `pymongo`, `selenium`).

### 4. Local automation via Makefile
Updated Makefile with new targets:

- `wait-web`: waits until `/register` returns HTTP 200
- `ui-e2e`: full local/CI E2E execution flow

`ui-e2e` performs:
- install test dependencies
- start `dbserver` and `webserver`
- wait for app readiness
- run pytest suite
- print service logs on failure
- always teardown containers/volumes

### 5. CI integration
Extended .github/workflows/static-analysis.yml:

- Added dedicated `ui-e2e` job (after `verify`)
- Sets up Python runtime
- Installs Firefox + geckodriver
- Reuses `make ui-e2e` (single source of truth for execution flow)

## Local run
From repo root:
- `make ui-e2e`

Optional:
- `GECKODRIVER_PATH=/opt/homebrew/bin/geckodriver make ui-e2e`

## Notes
- Tests are idempotent and use targeted cleanup to avoid DB pollution.