### PR TITLE
Enable TLS setup and post-deploy HTTPS verification for itu-minitwit.me

### DIFF
--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -16,6 +16,7 @@ on:
 # SSH_USER
 # SSH_KEY
 # SSH_HOST
+# TLS_DOMAIN (optional; when set, enables post-deploy TLS checks)
 
 jobs:
   build:
@@ -113,3 +114,39 @@ jobs:
           DIGITAL_OCEAN_DATABASE_USERNAME: ${{ secrets.DIGITAL_OCEAN_DATABASE_USERNAME }}
           DIGITAL_OCEAN_DATABASE_PWD: ${{ secrets.DIGITAL_OCEAN_DATABASE_PWD }}
           DIGITAL_OCEAN_DATABASE_NAME: ${{ secrets.DIGITAL_OCEAN_DATABASE_NAME }}
+
+      - name: Post-deploy TLS verification
+        run: |
+          if [ -z "${TLS_DOMAIN:-}" ]; then
+            echo "TLS_DOMAIN is not set. Skipping post-deploy TLS verification."
+            exit 0
+          fi
+
+          DOMAIN="${TLS_DOMAIN}"
+
+          echo "Running remote Nginx/certificate checks on $SSH_HOST..."
+          ssh $SSH_USER@$SSH_HOST -i ~/.ssh/ssh_key_golang_minitwit -o StrictHostKeyChecking=no '
+            set -e
+            sudo nginx -t
+            sudo systemctl is-active nginx >/dev/null
+            sudo certbot certificates
+          '
+
+          echo "Validating HTTP -> HTTPS redirect for ${DOMAIN}..."
+          HTTP_HEADERS=$(curl -sSI "http://${DOMAIN}")
+          echo "$HTTP_HEADERS"
+          echo "$HTTP_HEADERS" | grep -Ei '^HTTP/.* (301|308)'
+          echo "$HTTP_HEADERS" | grep -Ei '^location: https://'
+
+          echo "Validating HTTPS availability for ${DOMAIN}..."
+          HTTPS_HEADERS=$(curl -sSI "https://${DOMAIN}")
+          echo "$HTTPS_HEADERS"
+          echo "$HTTPS_HEADERS" | grep -Ei '^HTTP/.* (200|301|302)'
+
+          echo "Validating certificate chain for ${DOMAIN}..."
+          CERT_CHECK=$(echo | openssl s_client -connect "${DOMAIN}:443" -servername "${DOMAIN}" 2>/dev/null)
+          echo "$CERT_CHECK" | grep "Verify return code: 0"
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          TLS_DOMAIN: ${{ secrets.TLS_DOMAIN }}

--- a/remote_files/bootstrap_droplet_tls.sh
+++ b/remote_files/bootstrap_droplet_tls.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-time server bootstrap for Nginx + Let's Encrypt on Ubuntu.
+# Usage:
+#   sudo DOMAIN=itu-minitwit.me EMAIL=you@example.com APP_UPSTREAM_PORT=8080 ./bootstrap_droplet_tls.sh
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Please run as root (sudo)."
+  exit 1
+fi
+
+DOMAIN="${DOMAIN:-}"
+EMAIL="${EMAIL:-}"
+APP_UPSTREAM_PORT="${APP_UPSTREAM_PORT:-8080}"
+SERVER_NAME="${SERVER_NAME:-$DOMAIN www.$DOMAIN}"
+
+if [[ -z "${DOMAIN}" ]]; then
+  echo "DOMAIN is required. Example: DOMAIN=itu-minitwit.me"
+  exit 1
+fi
+
+if [[ -z "${EMAIL}" ]]; then
+  echo "EMAIL is required. Example: EMAIL=you@example.com"
+  exit 1
+fi
+
+echo "Installing Nginx and Certbot..."
+apt-get update
+apt-get install -y nginx certbot python3-certbot-nginx
+
+echo "Configuring firewall (ufw) if available..."
+if command -v ufw >/dev/null 2>&1; then
+  ufw allow OpenSSH || true
+  ufw allow 'Nginx Full' || true
+fi
+
+NGINX_CONF_PATH="/etc/nginx/sites-available/${DOMAIN}.conf"
+
+echo "Creating Nginx reverse-proxy config at ${NGINX_CONF_PATH}..."
+cat > "${NGINX_CONF_PATH}" <<EOF
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name ${SERVER_NAME};
+
+    location / {
+        proxy_pass http://127.0.0.1:${APP_UPSTREAM_PORT};
+        proxy_set_header Host \$http_host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+EOF
+
+ln -sf "${NGINX_CONF_PATH}" "/etc/nginx/sites-enabled/${DOMAIN}.conf"
+rm -f /etc/nginx/sites-enabled/default
+
+echo "Validating and reloading Nginx..."
+nginx -t
+systemctl reload nginx
+
+echo "Requesting TLS certificate from Let's Encrypt..."
+certbot --nginx -d "${DOMAIN}" -d "www.${DOMAIN}" --non-interactive --agree-tos -m "${EMAIL}" --redirect
+
+echo "Testing cert renewal (dry run)..."
+certbot renew --dry-run
+
+echo "Bootstrap completed for ${DOMAIN}."


### PR DESCRIPTION

## What was done

1. Registered a new domain on Namecheap: itu-minitwit.me
2. Configured DNS records in Namecheap:
3. Added one-time droplet bootstrap script to install/configure Nginx + Certbot and issue certificates.
4. Added CI post-deploy TLS verification step (redirect, HTTPS response, certificate validation) gated by TLS_DOMAIN.

## Required setup

1. Set TLS_DOMAIN in GitHub repository secrets:

- Open repository on GitHub
- Go to Settings
- Go to Secrets and variables -> Actions
- Under Secrets, click New repository secret
- Name: TLS_DOMAIN
- Value: itu-minitwit.me
- Save

2. Run one-time bootstrap on droplet:

```
scp remote_files/bootstrap_droplet_tls.sh <ssh_user>@164.90.229.101:/tmp/bootstrap_droplet_tls.sh
ssh <ssh_user>@164.90.229.101 'sudo DOMAIN=itu-minitwit.me EMAIL=<team_email> APP_UPSTREAM_PORT=8080 bash /tmp/bootstrap_droplet_tls.sh'
```
**What to replace for <team_email>**
Use a real team(or personal) mailbox for certificate notifications.

3. Deployment when other tasks are done and everything is ready
After secret setup and bootstrap, run a deployment so CI can execute post-deploy TLS checks and confirm HTTPS is healthy.

Verify if these domains are reachable:
```
curl -I http://itu-minitwit.me
curl -I https://itu-minitwit.me
curl -I https://www.itu-minitwit.me
```
And see if CI post-deploy TLS verification passes.
